### PR TITLE
Add Photo Clean core library and CLI monorepo setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.dart_tool/
+.packages
+.pub-cache/
+.buildlog/
+.flutter-plugins
+.flutter-plugins-dependencies
+.idea/
+.vscode/
+build/
+coverage/
+*.dart_tool/
+.DS_Store
+pubspec.lock
+packages/*/pubspec.lock

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 photo_clean
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# clean-tool-package
+# Photo Clean Monorepo
+
+Photo Clean 是一个包含核心图像相似度算法与命令行工具的 Dart monorepo，帮助你快速检测相似或模糊的图片。
+
+## Packages
+
+- **photo_clean_core**：纯 Dart 库，封装 pHash、Laplacian 方差与基于哈希的简单聚类算法。
+- **photo_clean_cli**：命令行工具，基于 `photo_clean_core`，扫描文件夹中的图片并输出相似分组以及可能的模糊照片。
+
+## 快速开始
+
+1. 安装 Dart SDK (>= 3.5.0)。
+2. 在仓库根目录执行依赖安装：
+   ```bash
+   dart pub get
+   ```
+3. 运行测试：
+   ```bash
+   dart test
+   ```
+4. 执行命令行工具（自动代理到 `packages/photo_clean_cli`）：
+   ```bash
+   dart run bin/photo_clean_cli.dart <images_folder> [phash_threshold=10] [blur_threshold=250]
+   ```
+
+## Packages 说明
+
+### photo_clean_core
+
+- 目录：`packages/photo_clean_core`
+- 依赖：[`image`](https://pub.dev/packages/image) 与 [`collection`](https://pub.dev/packages/collection)
+- 核心能力：
+  - `pHash64`：对图片进行缩放、灰度化、DCT-II、基于中位数生成 64bit 感知哈希。
+  - `hamming64`：计算两个 64bit 哈希的汉明距离。
+  - `laplacianVariance`：使用 3x3 Laplacian 核衡量灰度图清晰度。
+  - `clusterByPhash`：按阈值聚类（O(n²)），将相似图片分组。
+- 在该目录执行 `dart test` 可运行核心库的单元测试。
+
+### photo_clean_cli
+
+- 目录：`packages/photo_clean_cli`
+- 依赖：`photo_clean_core`（path 依赖）、`image`、`path`
+- 功能：遍历指定目录的图片文件（jpg/jpeg/png/bmp/webp），计算 pHash 与 Laplacian 方差，输出相似分组并标记疑似模糊的图片。
+- 在该目录执行 `dart run bin/photo_clean_cli.dart <folder>` 可直接运行。
+
+## 许可证
+
+本项目使用 [MIT License](LICENSE)。

--- a/bin/photo_clean_cli.dart
+++ b/bin/photo_clean_cli.dart
@@ -1,0 +1,8 @@
+import 'dart:io';
+
+import 'package:photo_clean_cli/photo_clean_cli.dart' as cli;
+
+Future<void> main(List<String> args) async {
+  final exitCodeValue = await cli.runCli(args);
+  exit(exitCodeValue);
+}

--- a/packages/photo_clean_cli/README.md
+++ b/packages/photo_clean_cli/README.md
@@ -1,0 +1,31 @@
+# photo_clean_cli
+
+命令行工具，用于扫描目录中的图片并寻找相似或模糊的文件。依赖 `photo_clean_core` 中的算法实现。
+
+## 安装依赖
+
+在仓库根目录执行：
+
+```bash
+dart pub get
+```
+
+## 使用方式
+
+在 `packages/photo_clean_cli` 目录下运行：
+
+```bash
+dart run bin/photo_clean_cli.dart <images_folder> [phash_threshold=10] [blur_threshold=250]
+```
+
+参数说明：
+
+- `images_folder`：需要扫描的图片目录。
+- `phash_threshold`：相似图片聚类的汉明距离阈值，默认 10。
+- `blur_threshold`：Laplacian 方差阈值，小于该值的图片会被判定为模糊，默认 250。
+
+程序将输出：
+
+- 成功处理的图片数量以及跳过的文件数量。
+- 根据感知哈希聚类得到的相似图片分组。
+- 疑似模糊的图片列表。

--- a/packages/photo_clean_cli/bin/photo_clean_cli.dart
+++ b/packages/photo_clean_cli/bin/photo_clean_cli.dart
@@ -1,0 +1,8 @@
+import 'dart:io';
+
+import 'package:photo_clean_cli/photo_clean_cli.dart' as cli;
+
+Future<void> main(List<String> args) async {
+  final code = await cli.runCli(args);
+  exit(code);
+}

--- a/packages/photo_clean_cli/lib/photo_clean_cli.dart
+++ b/packages/photo_clean_cli/lib/photo_clean_cli.dart
@@ -1,0 +1,137 @@
+library photo_clean_cli;
+
+import 'dart:io';
+
+import 'package:image/image.dart' as img;
+import 'package:path/path.dart' as p;
+import 'package:photo_clean_core/photo_clean_core.dart';
+
+/// Entry point used by both the standalone executable and the workspace proxy.
+Future<int> runCli(List<String> args, {IOSink? out, IOSink? err}) async {
+  out ??= stdout;
+  err ??= stderr;
+
+  if (args.isEmpty) {
+    _printUsage(err);
+    return 64;
+  }
+
+  final directory = Directory(args.first);
+  if (!directory.existsSync()) {
+    err.writeln('Directory not found: ${args.first}');
+    return 64;
+  }
+
+  final threshold = args.length > 1 ? int.tryParse(args[1]) ?? 10 : 10;
+  final blurThreshold =
+      args.length > 2 ? double.tryParse(args[2]) ?? 250.0 : 250.0;
+
+  final files = await _collectImageFiles(directory);
+  if (files.isEmpty) {
+    out.writeln('No images found in ${directory.path}.');
+    return 0;
+  }
+
+  final processedNames = <String>[];
+  final hashes = <BigInt>[];
+  final blurValues = <double>[];
+  final skipped = <String>[];
+  final basePath = directory.absolute.path;
+
+  for (final file in files) {
+    try {
+      final bytes = await file.readAsBytes();
+      final decoded = img.decodeImage(bytes);
+      if (decoded == null) {
+        skipped.add(file.path);
+        continue;
+      }
+
+      final resized = img.copyResize(
+        decoded,
+        width: 256,
+        height: 256,
+        interpolation: img.Interpolation.linear,
+      );
+
+      final hash = pHash64(resized);
+      final blur = laplacianVariance(resized);
+
+      hashes.add(hash);
+      blurValues.add(blur);
+      processedNames.add(p.relative(file.path, from: basePath));
+    } catch (_) {
+      skipped.add(file.path);
+    }
+  }
+
+  out.writeln(
+      'Processed ${processedNames.length} images from ${directory.path}.');
+  if (skipped.isNotEmpty) {
+    out.writeln('Skipped ${skipped.length} files (failed to decode).');
+  }
+
+  if (hashes.isEmpty) {
+    out.writeln('No decodable images found.');
+    return skipped.isEmpty ? 0 : 1;
+  }
+
+  final clusters = clusterByPhash(hashes, threshold: threshold);
+  final grouped = clusters.where((cluster) => cluster.length > 1).toList();
+
+  if (grouped.isEmpty) {
+    out.writeln('No similar image groups found (threshold $threshold).');
+  } else {
+    out.writeln('Similar image groups (threshold $threshold):');
+    for (var i = 0; i < grouped.length; i++) {
+      final cluster = grouped[i];
+      out.writeln('Group ${i + 1} (size ${cluster.length}):');
+      for (final index in cluster) {
+        out.writeln('  ${processedNames[index]}');
+      }
+    }
+  }
+
+  final blurry = <String>[];
+  for (var i = 0; i < processedNames.length; i++) {
+    if (blurValues[i] < blurThreshold) {
+      blurry.add(
+        '${processedNames[i]} (variance ${blurValues[i].toStringAsFixed(2)})',
+      );
+    }
+  }
+
+  if (blurry.isEmpty) {
+    out.writeln('No blurry images below threshold $blurThreshold.');
+  } else {
+    out.writeln('Potentially blurry images (variance < $blurThreshold):');
+    for (final entry in blurry) {
+      out.writeln('  $entry');
+    }
+  }
+
+  return 0;
+}
+
+Future<List<File>> _collectImageFiles(Directory directory) async {
+  final allowedExtensions = {'.jpg', '.jpeg', '.png', '.bmp', '.webp'};
+  final files = <File>[];
+  await for (final entity
+      in directory.list(recursive: true, followLinks: false)) {
+    if (entity is File) {
+      final ext = p.extension(entity.path).toLowerCase();
+      if (allowedExtensions.contains(ext)) {
+        files.add(entity);
+      }
+    }
+  }
+  files.sort((a, b) => a.path.compareTo(b.path));
+  return files;
+}
+
+void _printUsage(IOSink sink) {
+  sink.writeln(
+    'Usage: dart run bin/photo_clean_cli.dart <images_folder> '
+    '[phash_threshold=10] [blur_threshold=250]',
+  );
+}

--- a/packages/photo_clean_cli/pubspec.yaml
+++ b/packages/photo_clean_cli/pubspec.yaml
@@ -1,0 +1,14 @@
+name: photo_clean_cli
+description: Command-line interface for Photo Clean.
+version: 0.1.0
+publish_to: none
+resolution: workspace
+environment:
+  sdk: '>=3.5.0 <4.0.0'
+dependencies:
+  image: ^4.2.0
+  path: ^1.9.0
+  photo_clean_core:
+    path: ../photo_clean_core
+dev_dependencies:
+  test: ^1.24.0

--- a/packages/photo_clean_core/README.md
+++ b/packages/photo_clean_core/README.md
@@ -1,0 +1,18 @@
+# photo_clean_core
+
+纯 Dart 图像处理工具库，提供感知哈希、汉明距离、Laplacian 方差与基于哈希的简单聚类函数。
+
+## 功能
+
+- `pHash64(img.Image image, {int size = 32, int dctSize = 8})`：计算 64 bit 感知哈希。
+- `hamming64(BigInt a, BigInt b)`：计算 64 bit 哈希之间的汉明距离。
+- `laplacianVariance(img.Image image)`：使用 3×3 Laplacian kernel 计算图像清晰度指标。
+- `clusterByPhash(List<BigInt> hashes, {int threshold = 10})`：O(n²) 的简单聚类，汉明距离小于等于阈值时归为同一组。
+
+## 开发
+
+```bash
+cd packages/photo_clean_core
+dart pub get
+dart test
+```

--- a/packages/photo_clean_core/lib/photo_clean_core.dart
+++ b/packages/photo_clean_core/lib/photo_clean_core.dart
@@ -1,0 +1,230 @@
+library photo_clean_core;
+
+import 'dart:math' as math;
+
+import 'package:collection/collection.dart';
+import 'package:image/image.dart' as img;
+
+/// Generate a 64-bit perceptual hash for the provided [img.Image].
+///
+/// The algorithm downsamples the image to [size]×[size], converts it to
+/// grayscale, performs a 2D DCT-II and then looks at the top-left [dctSize]×
+/// [dctSize] coefficients. The DC coefficient (0,0) is excluded from the
+/// threshold calculation but still contributes a bit so the returned hash has
+/// `[dctSize] * [dctSize]` bits (64 when `dctSize == 8`).
+BigInt pHash64(img.Image image, {int size = 32, int dctSize = 8}) {
+  if (size <= 0) {
+    throw ArgumentError.value(size, 'size', 'Size must be positive');
+  }
+  if (dctSize <= 0) {
+    throw ArgumentError.value(dctSize, 'dctSize', 'dctSize must be positive');
+  }
+  if (dctSize > size) {
+    throw ArgumentError.value(
+      dctSize,
+      'dctSize',
+      'dctSize must be smaller than or equal to the resize size',
+    );
+  }
+
+  final resized = img.copyResize(
+    image,
+    width: size,
+    height: size,
+    interpolation: img.Interpolation.linear,
+  );
+  final grayscale = img.grayscale(resized);
+
+  final pixels = List.generate(
+    size,
+    (y) => List<double>.filled(size, 0.0, growable: false),
+    growable: false,
+  );
+  for (var y = 0; y < size; y++) {
+    for (var x = 0; x < size; x++) {
+      final pixel = grayscale.getPixel(x, y);
+      pixels[y][x] = pixel.luminance.toDouble();
+    }
+  }
+
+  final dct = _dct2D(pixels);
+  final coefficients = <double>[];
+  for (var v = 0; v < dctSize; v++) {
+    for (var u = 0; u < dctSize; u++) {
+      coefficients.add(dct[v][u]);
+    }
+  }
+
+  if (coefficients.isEmpty) {
+    return BigInt.zero;
+  }
+
+  final valuesWithoutDc =
+      coefficients.length > 1 ? coefficients.sublist(1) : coefficients;
+  final threshold = _median(valuesWithoutDc);
+
+  BigInt hash = BigInt.zero;
+  for (var i = 0; i < coefficients.length; i++) {
+    hash <<= 1;
+    if (i == 0) {
+      continue; // Skip the DC component bit.
+    }
+    if (coefficients[i] > threshold) {
+      hash |= BigInt.one;
+    }
+  }
+  return hash;
+}
+
+/// Compute the Hamming distance between two 64-bit perceptual hashes.
+int hamming64(BigInt a, BigInt b) {
+  var value = a ^ b;
+  var count = 0;
+  while (value != BigInt.zero) {
+    value &= (value - BigInt.one);
+    count++;
+  }
+  return count;
+}
+
+/// Compute the Laplacian variance on a grayscale version of [image].
+///
+/// The image is converted to grayscale (if necessary) before applying the
+/// 3×3 Laplacian kernel `[0, 1, 0; 1, -4, 1; 0, 1, 0]`. The variance of the
+/// filter response is returned — a larger value indicates a sharper image.
+double laplacianVariance(img.Image image) {
+  final grayscale = image.numChannels == 1 ? image : img.grayscale(image);
+  if (grayscale.width < 3 || grayscale.height < 3) {
+    return 0.0;
+  }
+
+  final responses = <double>[];
+  for (var y = 1; y < grayscale.height - 1; y++) {
+    for (var x = 1; x < grayscale.width - 1; x++) {
+      final value = _luminance(grayscale, x, y - 1) +
+          _luminance(grayscale, x - 1, y) +
+          _luminance(grayscale, x + 1, y) +
+          _luminance(grayscale, x, y + 1) -
+          4 * _luminance(grayscale, x, y);
+      responses.add(value);
+    }
+  }
+
+  if (responses.isEmpty) {
+    return 0.0;
+  }
+
+  final mean = responses.sum / responses.length;
+  final variance = responses.map((value) {
+        final diff = value - mean;
+        return diff * diff;
+      }).sum /
+      responses.length;
+  return variance;
+}
+
+/// Group image hashes by Hamming distance using a simple union-find clusterer.
+List<List<int>> clusterByPhash(List<BigInt> hashes, {int threshold = 10}) {
+  if (hashes.isEmpty) {
+    return <List<int>>[];
+  }
+
+  final parent = List<int>.generate(hashes.length, (index) => index);
+
+  int find(int index) {
+    if (parent[index] != index) {
+      parent[index] = find(parent[index]);
+    }
+    return parent[index];
+  }
+
+  void union(int a, int b) {
+    final rootA = find(a);
+    final rootB = find(b);
+    if (rootA == rootB) {
+      return;
+    }
+    parent[rootB] = rootA;
+  }
+
+  for (var i = 0; i < hashes.length; i++) {
+    for (var j = i + 1; j < hashes.length; j++) {
+      if (hamming64(hashes[i], hashes[j]) <= threshold) {
+        union(i, j);
+      }
+    }
+  }
+
+  final clusters = <int, List<int>>{};
+  for (var i = 0; i < hashes.length; i++) {
+    final root = find(i);
+    clusters.putIfAbsent(root, () => <int>[]).add(i);
+  }
+
+  final result = clusters.values.map((cluster) => (cluster..sort())).toList()
+    ..sort((a, b) => a.first.compareTo(b.first));
+  return result;
+}
+
+double _luminance(img.Image image, int x, int y) {
+  final pixel = image.getPixel(x, y);
+  return pixel.luminance.toDouble();
+}
+
+List<List<double>> _dct2D(List<List<double>> input) {
+  final size = input.length;
+  final output = List.generate(
+    size,
+    (_) => List<double>.filled(size, 0.0, growable: false),
+    growable: false,
+  );
+
+  final factor = math.pi / (2.0 * size);
+  final cosTableX = List.generate(
+    size,
+    (u) => List<double>.generate(
+        size, (x) => math.cos((2 * x + 1) * u * factor),
+        growable: false),
+    growable: false,
+  );
+  final cosTableY = List.generate(
+    size,
+    (v) => List<double>.generate(
+        size, (y) => math.cos((2 * y + 1) * v * factor),
+        growable: false),
+    growable: false,
+  );
+
+  final scale0 = math.sqrt(1.0 / size);
+  final scale = math.sqrt(2.0 / size);
+
+  for (var v = 0; v < size; v++) {
+    for (var u = 0; u < size; u++) {
+      var sum = 0.0;
+      for (var y = 0; y < size; y++) {
+        final row = input[y];
+        final cosY = cosTableY[v][y];
+        for (var x = 0; x < size; x++) {
+          sum += row[x] * cosTableX[u][x] * cosY;
+        }
+      }
+      final alphaU = u == 0 ? scale0 : scale;
+      final alphaV = v == 0 ? scale0 : scale;
+      output[v][u] = alphaU * alphaV * sum;
+    }
+  }
+
+  return output;
+}
+
+double _median(List<double> values) {
+  if (values.isEmpty) {
+    return 0.0;
+  }
+  final sorted = [...values]..sort();
+  final mid = sorted.length ~/ 2;
+  if (sorted.length.isOdd) {
+    return sorted[mid];
+  }
+  return (sorted[mid - 1] + sorted[mid]) / 2.0;
+}

--- a/packages/photo_clean_core/pubspec.yaml
+++ b/packages/photo_clean_core/pubspec.yaml
@@ -1,0 +1,12 @@
+name: photo_clean_core
+description: Core perceptual hash and clustering utilities for Photo Clean.
+version: 0.1.0
+publish_to: none
+resolution: workspace
+environment:
+  sdk: '>=3.5.0 <4.0.0'
+dependencies:
+  image: ^4.2.0
+  collection: ^1.18.0
+dev_dependencies:
+  test: ^1.24.0

--- a/packages/photo_clean_core/test/photo_clean_core_test.dart
+++ b/packages/photo_clean_core/test/photo_clean_core_test.dart
@@ -1,0 +1,5 @@
+import 'shared_tests.dart';
+
+void main() {
+  definePhotoCleanCoreTests();
+}

--- a/packages/photo_clean_core/test/shared_tests.dart
+++ b/packages/photo_clean_core/test/shared_tests.dart
@@ -1,0 +1,37 @@
+import 'package:image/image.dart' as img;
+import 'package:photo_clean_core/photo_clean_core.dart';
+import 'package:test/test.dart';
+
+void definePhotoCleanCoreTests() {
+  test('pHash64 generates zero hash for a uniform image', () {
+    final image = img.Image(width: 32, height: 32);
+    img.fill(image, color: img.ColorRgb8(255, 255, 255));
+
+    final hash = pHash64(image);
+    expect(hash.isNegative, isFalse);
+    expect(hash.bitLength, lessThanOrEqualTo(64));
+  });
+
+  test('laplacianVariance captures contrast in an image', () {
+    final image = img.Image(width: 5, height: 5);
+    img.fill(image, color: img.ColorRgb8(0, 0, 0));
+    image.setPixelRgba(2, 2, 255, 255, 255, 255);
+
+    final variance = laplacianVariance(image);
+    expect(variance, greaterThan(0));
+  });
+
+  test('clusterByPhash groups hashes within the threshold', () {
+    final hashes = <BigInt>[
+      BigInt.zero,
+      BigInt.one,
+      BigInt.from(0xff),
+    ];
+
+    final clusters = clusterByPhash(hashes, threshold: 1);
+    final group = clusters.firstWhere((cluster) => cluster.contains(0));
+
+    expect(group, containsAll(<int>[0, 1]));
+    expect(group.length, 2);
+  });
+}

--- a/pictures/README.md
+++ b/pictures/README.md
@@ -1,0 +1,9 @@
+# Sample Pictures Folder
+
+将待检测的图片放在此目录下，然后运行：
+
+```bash
+dart run bin/photo_clean_cli.dart ./pictures
+```
+
+目录为空时，工具会提示未找到图片。

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,17 @@
+name: photo_clean_workspace
+description: Workspace entrypoint for Photo Clean packages.
+publish_to: none
+version: 0.1.0
+environment:
+  sdk: '>=3.5.0 <4.0.0'
+workspace:
+  - packages/photo_clean_core
+  - packages/photo_clean_cli
+dependencies:
+  photo_clean_core:
+    path: packages/photo_clean_core
+  photo_clean_cli:
+    path: packages/photo_clean_cli
+dev_dependencies:
+  test: ^1.24.0
+  image: ^4.2.0

--- a/test/photo_clean_core_test.dart
+++ b/test/photo_clean_core_test.dart
@@ -1,0 +1,5 @@
+import '../packages/photo_clean_core/test/shared_tests.dart' as shared;
+
+void main() {
+  shared.definePhotoCleanCoreTests();
+}


### PR DESCRIPTION
## Summary
- create the `photo_clean_core` Dart library with perceptual hash, Laplacian variance, and clustering utilities plus shared unit tests
- add the `photo_clean_cli` command-line package that scans image folders, groups similar files, and flags blurry shots
- document the monorepo layout with README, MIT license, workspace pubspec, and a sample pictures directory

## Testing
- dart test
- dart run bin/photo_clean_cli.dart ./pictures

------
https://chatgpt.com/codex/tasks/task_e_68ca0d5f3ca4832c809f8c6d4c5843f8